### PR TITLE
[FIX] TypeError: Item in ``from list'' not a string

### DIFF
--- a/httptools/parser/__init__.py
+++ b/httptools/parser/__init__.py
@@ -2,4 +2,4 @@ from .parser import *
 from .errors import *
 
 
-__all__ = parser.__all__ + errors.__all__
+__all__ = tuple(str(i) for i in parser.__all__ + errors.__all__)


### PR DESCRIPTION
``parser.__all__`` should contain only "str" values

For some reason, ``parser.parser.__all__`` is made of ``str`` but ``parser.errors.__all__`` is made of ``unicode``. This chokes ``import httptools`` on python 2.7.5 at least.