### PR TITLE
Put proper return type for HttpRequestParser.get_method()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class HttpRequestParser:
         set to the offset of the non-HTTP data in ``data``.
         """
 
-    def get_method(self) -> str:
+    def get_method(self) -> bytes:
         """Return HTTP request method (GET, HEAD, etc)"""
 
 


### PR DESCRIPTION
The method says it returns a type str, but actually returns bytes. Not sure if the method is intended to return bytes but it does.