### PR TITLE
Change HttpParser.get_http_version() to return bytes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class HttpRequestParser:
           - on_chunk_complete()
         """
 
-    def get_http_version(self) -> str:
+    def get_http_version(self) -> bytes:
         """Return an HTTP protocol version."""
 
     def should_keep_alive(self) -> bool:

--- a/httptools/parser/parser.pyx
+++ b/httptools/parser/parser.pyx
@@ -140,10 +140,10 @@ cdef class HttpParser:
 
     def get_http_version(self):
         cdef cparser.http_parser* parser = self._cparser
-        return '{}.{}'.format(parser.http_major, parser.http_minor)
+        return b'%d.%d' % (parser.http_major, parser.http_minor)
 
     def should_keep_alive(self):
-        return bool(cparser.http_should_keep_alive(self._cparser))
+        return cparser.http_should_keep_alive(self._cparser) != 0
 
     def feed_data(self, data):
         cdef:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -79,7 +79,7 @@ class TestResponseParser(unittest.TestCase):
         p = httptools.HttpResponseParser(m)
         p.feed_data(memoryview(RESPONSE1_HEAD))
 
-        self.assertEqual(p.get_http_version(), '1.1')
+        self.assertEqual(p.get_http_version(), b'1.1')
         self.assertEqual(p.get_status_code(), 200)
 
         m.on_status.assert_called_once_with(b'OK')
@@ -206,7 +206,7 @@ class TestResponseParser(unittest.TestCase):
 
         self.assertEqual(UPGRADE_RESPONSE1[offset:], b'data')
 
-        self.assertEqual(p.get_http_version(), '1.1')
+        self.assertEqual(p.get_http_version(), b'1.1')
         self.assertEqual(p.get_status_code(), 101)
 
         m.on_status.assert_called_once_with(b'Switching Protocols')
@@ -231,7 +231,7 @@ class TestRequestParser(unittest.TestCase):
         m.on_message_begin.assert_called_once_with()
 
         m.on_url.assert_called_once_with(b'/test.php?a=b+c')
-        self.assertEqual(p.get_http_version(), '1.2')
+        self.assertEqual(p.get_http_version(), b'1.2')
 
         m.on_header.assert_called_with(b'Transfer-Encoding', b'chunked')
         m.on_chunk_header.assert_called_with()
@@ -314,7 +314,7 @@ class TestRequestParser(unittest.TestCase):
         self.assertEqual(p.get_method(), b'POST')
 
         m.on_url.assert_called_once_with(b'/test.php?a=b+c')
-        self.assertEqual(p.get_http_version(), '1.2')
+        self.assertEqual(p.get_http_version(), b'1.2')
 
         m.on_header.assert_called_with(b'Transfer-Encoding', b'chunked')
         m.on_chunk_header.assert_called_with()


### PR DESCRIPTION
In current version of httptools HttpParser.get_http_version() returns a string while all other API functions return bytes. I think it makes more sense to return bytes to have a more homogeneous API and because this is supposed to be a lower-level library. Also a small speedup for keep_alive. @1st1 