### PR TITLE
Introduction of a method "should_upgrade"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ class HttpRequestParser:
     def should_keep_alive(self) -> bool:
         """Return ``True`` if keep-alive mode is preferred."""
 
+    def should_upgrade(self) -> bool:
+        """Return ``True`` if the parsed request is a valid Upgrade request.
+	The method exposes a flag set just before on_headers_complete.
+	Calling this method earlier will only yield `False`.
+	"""
+
     def feed_data(self, data: bytes):
         """Feed data to the parser.
 

--- a/httptools/parser/parser.pyx
+++ b/httptools/parser/parser.pyx
@@ -152,7 +152,8 @@ cdef class HttpParser:
         return bool(cparser.http_should_keep_alive(self._cparser))
 
     def should_upgrade(self):
-        return bool(self._cparser.upgrade)
+        cdef cparser.http_parser* parser = self._cparser
+        return bool(parser.upgrade)
 
     def feed_data(self, data):
         cdef:

--- a/httptools/parser/parser.pyx
+++ b/httptools/parser/parser.pyx
@@ -151,6 +151,9 @@ cdef class HttpParser:
     def should_keep_alive(self):
         return bool(cparser.http_should_keep_alive(self._cparser))
 
+    def should_upgrade(self):
+        return bool(self._cparser.upgrade)
+
     def feed_data(self, data):
         cdef:
             size_t data_len

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -348,6 +348,26 @@ class TestRequestParser(unittest.TestCase):
             b'Host': b'example.com',
             b'Upgrade': b'WebSocket'})
 
+    def test_parser_request_upgrade_flag(self):
+        m = mock.Mock()
+        p = httptools.HttpRequestParser(m)
+
+        def on_headers_complete():
+            self.assertEqual(p.should_upgrade(), False)
+
+        def on_message_complete():
+            self.assertEqual(p.should_upgrade(), True)
+
+        m.on_headers_complete = on_headers_complete
+        m.on_message_complete = on_message_complete
+    
+        try:
+            p.feed_data(UPGRADE_REQUEST1)
+        except httptools.HttpParserUpgrade as ex:
+            offset = ex.args[0]
+        else:
+            self.fail('HttpParserUpgrade was not raised')
+        
     def test_parser_request_error_in_on_header(self):
         class Error(Exception):
             pass

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -367,11 +367,12 @@ class TestRequestParser(unittest.TestCase):
         protocol = Protocol()
         try:
             protocol.parser.feed_data(UPGRADE_REQUEST1)
-        except httptools.HttpParserUpgrade as ex:
-            offset = ex.args[0]
+        except httptools.HttpParserUpgrade:
+            # Raise as usual.
+            pass
         else:
             self.fail('HttpParserUpgrade was not raised')
-        
+
     def test_parser_request_error_in_on_header(self):
         class Error(Exception):
             pass


### PR DESCRIPTION
While working on a HTTP Protocol, I encountered a problem relative to the late raise of the HttpParserUpgrade exception. I need to know, in on_headers_complete and in on_message_complete if the current request is an Upgrade Request or not.

This PR introduces a method on the request parser called `should_upgrade` that exposes the cparser upgrade flag, to be able to know as soon as possible if the request is or not an upgrade.

This doesn't change the raise of HttpParserUpgrade but allows to act earlier.