### PR TITLE
Update use of Pathlib to be python 3.5 compatible.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,18 +117,18 @@ class httptools_build_ext(build_ext):
                 self.compiler.add_include_dir('/opt/local/include')
         else:
             self.compiler.add_include_dir(
-                    os.path.join(ROOT, 'vendor/http-parser'))
+                    ROOT.joinpath('vendor/http-parser'))
             self.distribution.ext_modules[0].sources.append(
                 'vendor/http-parser/http_parser.c')
 
         super().build_extensions()
 
 
-with open(os.path.join(ROOT, 'README.md')) as f:
+with open(ROOT.joinpath('README.md')) as f:
     long_description = f.read()
 
 
-with open(os.path.join(ROOT, 'httptools', '_version.py')) as f:
+with open(ROOT.joinpath('httptools', '_version.py')) as f:
     for line in f:
         if line.startswith('__version__ ='):
             _, _, version = line.partition('=')

--- a/setup.py
+++ b/setup.py
@@ -124,11 +124,11 @@ class httptools_build_ext(build_ext):
         super().build_extensions()
 
 
-with open(ROOT.joinpath('README.md')) as f:
+with ROOT.joinpath('README.md').open() as f:
     long_description = f.read()
 
 
-with open(ROOT.joinpath('httptools', '_version.py')) as f:
+with ROOT.joinpath('httptools', '_version.py').open() as f:
     for line in f:
         if line.startswith('__version__ ='):
             _, _, version = line.partition('=')


### PR DESCRIPTION
Recent updates to how Paths are defined in setup.py was causing failures when installing on python 3.5, this PR updates setup.py to use pathlib utilities instead of os.path utilities when operating on pathlib.Path objects. 