### PR TITLE
Fix httptools.__all__

### DIFF
--- a/httptools/__init__.py
+++ b/httptools/__init__.py
@@ -1,6 +1,6 @@
-from .parser import parser
+from . import parser
 from .parser import *  # NOQA
 
 from ._version import __version__  # NOQA
 
-__all__ = parser.__all__  # NOQA
+__all__ = parser.__all__ + ('__version__',)  # NOQA

--- a/httptools/parser/__init__.py
+++ b/httptools/parser/__init__.py
@@ -1,5 +1,4 @@
-from .parser import *
-from .errors import *
+from .parser import *  # NoQA
+from .errors import *  # NoQA
 
-
-__all__ = parser.__all__ + errors.__all__
+__all__ = parser.__all__ + errors.__all__  # NoQA


### PR DESCRIPTION
While looking at #52, I noticed that `httptools.__all__` is incorrect
and doesn't actually include everything that is exported by the module,
which might entice the users to import from the private submodule
directly.

Fixes: #52