### PR TITLE
Stop pinning to an exact version of Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ CFLAGS = ['-O2']
 
 ROOT = pathlib.Path(__file__).parent
 
-CYTHON_DEPENDENCY = 'Cython==0.29.22'
+CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 
 class httptools_build_ext(build_ext):


### PR DESCRIPTION
Cython 0.29 is in maintenance mode, so the risk of big breakage is low.
On the other hand, this maintenance picks up important fixes, including
support for newer Pythons.  Furthermore, pinning to an exact version
may cause conflicts if something else pins to a slightly different version.