### PR TITLE
httptools 0.3.0

### DIFF
--- a/httptools/_version.py
+++ b/httptools/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'


### PR DESCRIPTION
This release has no functional changes, only packaging: Python 3.5 is
EOL, so wheels are no longer built, and Python 3.10 has been added to
the roster along with aarch64 wheels on Linux and universal2 wheels on
macOS.

Changes:

* Use cibuildwheel to build release wheels
  (by @elprans in 2f57b6b7)