### PR TITLE
httptools 0.4.0

### DIFF
--- a/httptools/_version.py
+++ b/httptools/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'


### PR DESCRIPTION
Changes
=======

* Bump bundled http-parser to 2.9.4 and llhttp to 6.0.6
  fixes CVE-2021-22959 & CVE-2021-22960
  (by @elprans in 4d5dddd3 for #77)