### PR TITLE
httptools 0.5.0

### DIFF
--- a/httptools/_version.py
+++ b/httptools/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'


### PR DESCRIPTION
Changes
=======

* Bump bundled llhttp to 6.0.9
  fixes CVE-2022-32213, CVE-2022-32214, CVE-2022-32215
  (by @nlsj1985 in 56d6a163 for #83)

* Test and build against Python 3.11
  (by @elprans in 509cd149 for #84)