### PR TITLE
bump to llhttp v6.0.10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,3 @@
 [submodule "vendor/llhttp"]
 	path = vendor/llhttp
 	url = https://github.com/nodejs/llhttp.git
-	branch = release


### PR DESCRIPTION
Please bump httptools version.
It seems that there was some parsing issue remaining with regard to the CVE's 
llhttp v6.0.10 changelog:
http: disable chunked encoding when OBS fold is used

Fixes: https://hackerone.com/reports/1630336
Fixes: https://hackerone.com/reports/1665156
Fixes: https://hackerone.com/reports/1675191