### PR TITLE
bump llhttp to v6.0.11

### DIFF
--- a/httptools/_version.py
+++ b/httptools/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.5.0'
+__version__ = '0.6.0'


### PR DESCRIPTION

related to https://hackerone.com/reports/2001873
fix: Do not allow empty header separated by CR. by @ShogunPanda in https://github.com/nodejs/llhttp/pull/228

compare
https://github.com/nodejs/llhttp/compare/v6.0.10...v6.0.11