### PR TITLE
httptools 0.6.1

### DIFF
--- a/httptools/_version.py
+++ b/httptools/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'


### PR DESCRIPTION
Changes
=======

* Explicit Python 3.12 support and build wheels, change min version to 3.8 (#95)
  (by @tiptenbrink in 25f412bd for #95)

* Do not install the *.c sources in wheels (#73)
  (by @hroncok in b2fc5bdf for #73)