### PR TITLE
httptools 0.6.3

### DIFF
--- a/httptools/_version.py
+++ b/httptools/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'


### PR DESCRIPTION
Fixes
=====

* Fix missing CR is some tests
  (by @mgorny in 21a199d3 for #112)

* Bump bundled llhttp to 9.2.1
  Fixes CVE-2024-27982
  (by @elprans in 560bd9ea for #113)
