### PR TITLE
Move static metadata to a pyproject.toml file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,5 +46,5 @@ jobs:
       if: steps.release.outputs.version == 0
       run: |
         python -m pip install -U pip setuptools wheel
-        python -m pip install -e .[test]
+        python -m pip install .[test]
         python -m unittest -v tests.suite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools"]
+
+[project]
+name = "httptools"
+dynamic = ["version"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Operating System :: POSIX",
+    "Operating System :: MacOS :: MacOS X",
+    "Environment :: Web Environment",
+    "Development Status :: 5 - Production/Stable",
+]
+requires-python = ">=3.8"
+authors = [
+    {name = "Yury Selivanov", email="yury@magic.io"},
+]
+license = "MIT"
+description = "A collection of framework independent HTTP protocol utils."
+readme = "README.md"
+
+[project.urls]
+Homepage = "https://github.com/MagicStack/httptools"

--- a/setup.py
+++ b/setup.py
@@ -145,10 +145,6 @@ class httptools_build_ext(build_ext):
         super().build_extensions()
 
 
-with open(str(ROOT / 'README.md')) as f:
-    long_description = f.read()
-
-
 with open(str(ROOT / 'httptools' / '_version.py')) as f:
     for line in f:
         if line.startswith('__version__ ='):
@@ -169,27 +165,9 @@ if (not (ROOT / 'httptools' / 'parser' / 'parser.c').exists() or
 
 
 setup(
-    name='httptools',
     version=VERSION,
-    description='A collection of framework independent HTTP protocol utils.',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/MagicStack/httptools',
-    classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3',
-        'Operating System :: POSIX',
-        'Operating System :: MacOS :: MacOS X',
-        'Environment :: Web Environment',
-        'Development Status :: 5 - Production/Stable',
-    ],
     platforms=['macOS', 'POSIX', 'Windows'],
-    python_requires='>=3.8.0',
     zip_safe=False,
-    author='Yury Selivanov',
-    author_email='yury@magic.io',
-    license='MIT',
     packages=['httptools', 'httptools.parser'],
     cmdclass={
         'build_ext': httptools_build_ext,


### PR DESCRIPTION
CI hasn't run on this repo in almost a year. In the meantime the packaging tools have changed in such a way as to break the way the package is installed. See this build on my fork: https://github.com/ngoldbaum/httptools/actions/runs/18016652463/job/51263261330

The existence of a pyproject.toml file triggers PEP 517 build isolation, which I think will fix this issue. I moved all the static metadata to the static pyproject.toml file.

I think in principle you could make the build metadata completely static by simply delcaring Cython a build dependency and always generating the C/C++ code from the Cython sources on every install. IMO there's no need to include build C/C++ files in the sdist as is currently set up.