### PR TITLE
httptools 0.7.0

### DIFF
--- a/httptools/_version.py
+++ b/httptools/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.7.0.dev0'
+__version__ = '0.7.0'


### PR DESCRIPTION
Changes
=======

* Modernize packaging and fix CI (#130) 
  Drop Python 3.8, add Python 3.14
  Use Cython 3.1.0
  Bump llhttp to 9.3.0
  (by @ngoldbaum @Carreau @fantix in 59bf94fc for #129)

* Static Type-checking for httptools (#100)
  (by @Vizonex @KRRT7 in b55f5fe2 for #100)