### PR TITLE
Add http-parser and llhttp licenses into the wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 ]
 license = "MIT"
 license-files = [
-"LICENSE",
+    "LICENSE",
     "vendor/http-parser/LICENSE-MIT",
     "vendor/llhttp/LICENSE",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,11 @@ authors = [
     {name = "Yury Selivanov", email="yury@magic.io"},
 ]
 license = "MIT"
-license-files = ["LICENSE"]
+license-files = [
+"LICENSE",
+    "vendor/http-parser/LICENSE-MIT",
+    "vendor/llhttp/LICENSE",
+]
 description = "A collection of framework independent HTTP protocol utils."
 readme = "README.md"
 


### PR DESCRIPTION
The wheels should include http-parser and llhttp licenses. Add them. 