### PR TITLE
Allow building with latest setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools==80.9.0"]
+requires = ["setuptools>=80.9.0,<=82.0.1"]
 
 [project]
 name = "httptools"


### PR DESCRIPTION
This allows building with Setuptools v80+. In my local tests with Yocto it was working okay with the latest version.