### PR TITLE
Add PPC64LE support in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        cibw_arch: ["auto64", "aarch64", "universal2"]
+        cibw_arch: ["auto64", "aarch64", "universal2", "ppc64le"]
         cibw_python:
           - "cp39"
           - "cp310"
@@ -83,10 +83,14 @@ jobs:
             cibw_arch: universal2
           - os: macos-latest
             cibw_arch: aarch64
+          - os: macos-latest
+            cibw_arch: ppc64le
           - os: windows-latest
             cibw_arch: universal2
           - os: windows-latest
             cibw_arch: aarch64
+          - os: windows-latest
+            cibw_arch: ppc64le
 
     defaults:
       run:
@@ -102,10 +106,10 @@ jobs:
         submodules: true
 
     - name: Set up QEMU
-      if: matrix.os == 'ubuntu-latest' && matrix.cibw_arch == 'aarch64'
+      if: matrix.os == 'ubuntu-latest' && (matrix.cibw_arch == 'aarch64' || matrix.cibw_arch == 'ppc64le')
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf  # v3.2.0
       with:
-        platforms: arm64
+        platforms: arm64,ppc64le
 
     - uses: pypa/cibuildwheel@7c619efba910c04005a835b110b057fc28fd6e93  # v3.2.0
       env:


### PR DESCRIPTION
- This PR adds ppc64le wheel builds to the CI matrix, bringing Power (ppc64le) to parity with existing  platforms.
- As part of this change, release.yml has been updated to exclude incompatible OS targets ( macos-latest and windows-latest ) for ppc64le builds.
- We are prepared to provide any further details or assistance needed to support the PPC64LE architecture. Please let us know if there are any specific requirements or steps needed to move forward with this request.
