### PR TITLE
httptools 0.8.0

### DIFF
--- a/httptools/_version.py
+++ b/httptools/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.8.0.dev0'
+__version__ = '0.8.0'


### PR DESCRIPTION
Changes
=======

* Add http-parser and llhttp licenses into the wheels (#135)
  (by @justeph in c398a157)

* Mark cython module as free-threading compatible (#139)
  (by @kumaraditya303 in 28d1db15)

* Fix all typing issues (#134)
  (by @Kludex in a9bda0ed)

* Bump llhttp to 9.4.1 (#145)
  (by @fantix in e3e8d71e)

* Security: fix URL truncation issue (#144)
  (by @fantix in a0283f07 for #142)

* Allow building with latest setuptools (#138)
  (by @OldManYellsAtCloud in c403ad1a)